### PR TITLE
Replace Disco/Alpha/Beta/Live. 

### DIFF
--- a/app/views/components/index.html
+++ b/app/views/components/index.html
@@ -15,28 +15,75 @@
       <h1 class="heading-section">Components</h1>
       <p class="lede">Components are the building blocks that form patterns. They include example components and guidance on usage.</p>
 
-      <h2 class="heading-medium">Live</h2>
-      <ul class="list">
-        <li><a href="/components/typography">Typography</a>: advice on typography choices</li>
-      </ul>
+      {% set components = [
+        {
+          name: "Count badges",
+          link: "/components/badges",
+          label: "experimental",
+          desc: "quick identification of numeric values like tallies or quantities"
+        },
+        {
+          name: "Cards",
+          link: "/components/cards",
+          label: "experimental",
+          desc: "a list of content/links group into cards for visual clarity"
+        },
+        {
+          name: "Labels",
+          link: "/components/labels",
+          label: "experimental",
+          desc: "used to quickly identify commonly grouped or related items"
+        },
+        {
+          name: "Buttons",
+          link: "/components/buttons",
+          label: "experimental",
+          desc: "used when a user needs to take an action, submit data, or make a change to the page"
+        },
+        {
+          name: "Icons",
+          link: "/components/icons",
+          label: "Experimental",
+          desc: "full set of Home Office icons"
+        },
+        {
+          name: "Typography",
+          link: "/components/typography",
+          label: "recommended",
+          desc: "advice on typography choices"
+        }
+      ] %}
 
-      <h2 class="heading-medium">Beta</h2>
-      <ul class="list">
-        <li><a href="/components/icons">Icons</a>: full set of Home Office icons</li>
-      </ul>
+      <table class="mb-30">
+        <thead>
+          <tr>
+            <th>Component</th>
+            <th>Status</th>
+            <th>Description</th>
+          </tr>
+        </thead>
 
-      <h2 class="heading-medium">Alpha</h2>
-      <ul class="list">
-        <li><a href="/components/buttons">Buttons</a>: used when a user needs to take an action, submit data, or make a change to the page.</li>
-        <li><a href="/components/labels">Labels</a>: used to quickly identify commonly grouped or related items</li>
-        <!-- <li><a href="/components/modal">Modal</a>: creates focus on a single interaction</li> -->
-      </ul>
-
-      <h2 class="heading-medium">Discovery</h2>
-      <ul class="list">
-        <li><a href="/components/cards">Cards</a>: a list of content/links group into cards for visual clarity</li>
-        <li><a href="/components/badges">Count badges</a>: quick identification of numeric values like tallies or quantities</li>
-      </ul>
+        <tbody>
+          {% for component in components|sort(attribute='label') %}
+            {% if component.label|lower == 'recommended' %}
+              <tr>
+                <td><a href="{{ component.link }}">{{ component.name|capitalize  }}</a></td>
+                <td><span class="label--green">{{ component.label|lower }}</span></td>
+                <td>{{ component.desc|capitalize }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+          {% for component in components|sort(attribute='label') %}
+            {% if component.label|lower == 'experimental' %}
+              <tr>
+                <td><a href="{{ component.link }}">{{ component.name|capitalize  }}</a></td>
+                <td><span class="label--yellow">{{ component.label|lower }}</span></td>
+                <td>{{ component.desc|capitalize }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
 
     </div>
   </div>

--- a/app/views/patterns/index.html
+++ b/app/views/patterns/index.html
@@ -15,52 +15,105 @@
       <h1 class="heading-section">Patterns</h1>
       <p class="lede">Patterns developed by the Home Office DDaT user research and design teams to help develop and create consistent, usable services. They include example components and guidance on usage.</p>
 
-      <h2 class="heading-medium">Beta</h2>
-      <ul class="list">
+      {% set patterns = [
+        {
+          name: "Interruption card",
+          link: "/patterns/flash-card",
+          label: "experimental",
+          desc: "Interrupt the user flow with important information"
+        },
+        {
+          name: "Task checklist",
+          link: "/patterns/tasks",
+          label: "experimental",
+          desc: "a list of completed and still-to-do tasks"
+        },
+        {
+          name: "Contextual help",
+          link: "/patterns/help",
+          label: "experimental",
+          desc: "small overlays containing help content for complex interactions"
+        },
+        {
+          name: "Vertical timeline",
+          link: "/patterns/timeline",
+          label: "experimental",
+          desc: "time-ordered activity showing the history of a person or object with additional context"
+        },
+        {
+          name: "Table multi-select",
+          link: "/patterns/table-multiselect",
+          label: "experimental",
+          desc: "allow the user to select multiple rows by clicking anywhere on the row"
+        },
+        {
+          name: "Subnavigation links",
+          link: "/patterns/navigation",
+          label: "experimental",
+          desc: "navigate to different sections at any time"
+        },
+        {
+          name: "Modal window",
+          link: "/patterns/modal",
+          label: "experimental",
+          desc: "creates focus on a single interaction"
+        },
+        {
+          name: "In-page tabs",
+          link: "/patterns/tabs",
+          label: "experimental",
+          desc: "switch between views of grouped content or hide content that doesn't always need to be shown"
+        },
+        {
+          name: "Highlighted search matches",
+          link: "/patterns/highlighting-matches",
+          label: "experimental",
+          desc: "helps users identify matching data"
+        },
+        {
+          name: "Confirmation pages",
+          link: "/patterns/confirm-pages",
+          label: "Experimental",
+          desc: "variations for a service confirmation page"
+        },
+        {
+          name: "Service header",
+          link: "/patterns/header",
+          label: "recommended",
+          desc: "identify a common landmark at the top of every view"
+        }
+      ] %}
 
-        <li>
-          <a href="/patterns/flash-card">Interruption card</a>: interrupt the user flow with important information
-        </li>
-        <li>
-          <a href="/patterns/header">Service header</a>: identify a common landmark at the top of every view
-        </li>
+      <table class="mb-30">
+        <thead>
+          <tr>
+            <th>Pattern</th>
+            <th>Status</th>
+            <th>Description</th>
+          </tr>
+        </thead>
 
-      </ul>
-
-      <h2 class="heading-medium">Alpha</h2>
-      <ul class="list">
-        <li>
-          <a href="/patterns/confirm-pages">Confirmation pages</a>: variations for a service confirmation page
-        </li>
-        <li>
-          <a href="/patterns/highlighting-matches">Highlighted search matches</a>: helps users identify matching data
-        </li>
-        <li>
-          <a href="/patterns/tabs">In-page tabs</a>: switch between views of grouped content or hide content that doesn&rsquo;t always need to be shown
-        </li>
-        <li>
-          <a href="/patterns/modal">Modal window</a>: creates focus on a single interaction
-        </li>
-        <li>
-          <a href="/patterns/navigation">Subnavigation links</a>: navigate to different sections at any time
-        </li>
-        <li>
-          <a href="/patterns/table-multiselect">Table multi-select</a>: allow the user to select multiple rows by clicking anywhere on the row
-        </li>
-        <li>
-          <a href="/patterns/timeline">Vertical timeline</a>: time-ordered activity showing the history of a person or object with additional context
-        </li>
-      </ul>
-
-      <h2 class="heading-medium">Discovery</h2>
-      <ul class="list">
-        <li>
-          <a href="/patterns/help">Contextual help</a>: small overlays containing help content for complex interactions
-        </li>
-        <li>
-          <a href="/patterns/tasks">Task checklist</a>: a list of completed and still-to-do tasks
-        </li>
-      </ul>
+        <tbody>
+          {% for pattern in patterns|sort(attribute='label')|sort(attribute='name') %}
+            {% if pattern.label|lower == 'recommended' %}
+              <tr>
+                <td><a href="{{ pattern.link }}">{{ pattern.name|capitalize  }}</a></td>
+                <td><span class="label--green">{{ pattern.label|lower }}</span></td>
+                <td>{{ pattern.desc|capitalize }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+          {% for pattern in patterns|sort(attribute='label')|sort(attribute='name') %}
+            {% if pattern.label|lower == 'experimental' %}
+              <tr>
+                <td><a href="{{ pattern.link }}">{{ pattern.name|capitalize  }}</a></td>
+                <td><span class="label--yellow">{{ pattern.label|lower }}</span></td>
+                <td>{{ pattern.desc|capitalize }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
 
     </div>
   </div>


### PR DESCRIPTION
Replaced with recommended and experimental.

Restructured the components and patterns pages to use a table sorted first by recommended or experimental, then by name.